### PR TITLE
update readme to reflect that this is no longer actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This package is no longer actively maintained. See the [Posit blog](https://posit.co/blog/ending-active-maintenance-fastapitableau-plumbertableau-and-shinytableau) for more information.
+
 # shinytableau
 
 <!-- badges: start -->


### PR DESCRIPTION
adds a note to the top of the readme and links to https://posit.co/blog/ending-active-maintenance-fastapitableau-plumbertableau-and-shinytableau